### PR TITLE
chore: drop support for node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: node_js
 node_js:
 - 'stable'
+- '10'
 - '8'
-- '6'
 matrix:
   fast_finish: true
 branches:


### PR DESCRIPTION
Since standard-version drops support for node 6 we need to do so as
well.

BREAKING CHANGE: drop support for node 6