### PR TITLE
chore: drop support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
 - 'stable'
 - '10'
-- '8'
 matrix:
   fast_finish: true
 branches:


### PR DESCRIPTION
BREAKING CHANGE: drop support for node8